### PR TITLE
change api endpoint via env variable GITHUB_API_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ $ github-release delete \
     --tag v0.1.0
 ```
 
+GitHub Enterprise Support
+=========================
+You can point to a different GitHub API endpoint via the environment variable ```GITHUB_API_URL```:
+
+```
+export GITHUB_API_URL=http://github.company.com/api/v3
+```
+
 Used libraries
 ==============
 

--- a/api.go
+++ b/api.go
@@ -64,13 +64,13 @@ func DoAuthRequest(method, url, bodyType, token string, body io.Reader) (*http.R
 }
 
 func GithubGet(uri string, v interface{}) error {
-	resp, err := http.Get(API_URL + uri)
+	resp, err := http.Get(apiURL() + uri)
 	if err != nil {
 		return fmt.Errorf("could not fetch releases, %v", err)
 	}
 	defer resp.Body.Close()
 
-	vprintln("GET", API_URL+uri, "->", resp)
+	vprintln("GET", apiURL()+uri, "->", resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("github did not response with 200 OK but with %v", resp.Status)
@@ -90,4 +90,13 @@ func GithubGet(uri string, v interface{}) error {
 	}
 
 	return nil
+}
+
+func apiURL() string {
+	url := os.Getenv("GITHUB_API_URL")
+	if url == "" {
+		return API_URL
+	} else {
+		return url
+	}
 }


### PR DESCRIPTION
GitHub Enterprise Support (i.e. Specify a different API Endpoint via an environment variable)
