### PR TITLE
make env var consistent (and changed name), updated additional hard-coded url

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ $ github-release delete \
 
 GitHub Enterprise Support
 =========================
-You can point to a different GitHub API endpoint via the environment variable ```GITHUB_API_URL```:
+You can point to a different GitHub API endpoint via the environment variable ```GITHUB_API```:
 
 ```
-export GITHUB_API_URL=http://github.company.com/api/v3
+export GITHUB_API=http://github.company.com/api/v3
 ```
 
 Used libraries

--- a/api.go
+++ b/api.go
@@ -64,13 +64,13 @@ func DoAuthRequest(method, url, bodyType, token string, body io.Reader) (*http.R
 }
 
 func GithubGet(uri string, v interface{}) error {
-	resp, err := http.Get(apiURL() + uri)
+	resp, err := http.Get(ApiURL() + uri)
 	if err != nil {
 		return fmt.Errorf("could not fetch releases, %v", err)
 	}
 	defer resp.Body.Close()
 
-	vprintln("GET", apiURL()+uri, "->", resp)
+	vprintln("GET", ApiURL()+uri, "->", resp)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("github did not response with 200 OK but with %v", resp.Status)
@@ -92,11 +92,10 @@ func GithubGet(uri string, v interface{}) error {
 	return nil
 }
 
-func apiURL() string {
-	url := os.Getenv("GITHUB_API_URL")
-	if url == "" {
+func ApiURL() string {
+	if "" == EnvApiEndpoint {
 		return API_URL
 	} else {
-		return url
+		return EnvApiEndpoint
 	}
 }

--- a/github-release.go
+++ b/github-release.go
@@ -66,12 +66,14 @@ var (
 	EnvToken string
 	EnvUser  string
 	EnvRepo  string
+	EnvApiEndpoint string
 )
 
 func init() {
 	EnvToken = os.Getenv("GITHUB_TOKEN")
 	EnvUser = os.Getenv("GITHUB_USER")
 	EnvRepo = os.Getenv("GITHUB_REPO")
+	EnvApiEndpoint = os.Getenv("GITHUB_API")
 }
 
 func main() {
@@ -170,6 +172,7 @@ func uploadcmd(opt Options) error {
 
 	v := url.Values{}
 	v.Set("name", name)
+
 	url := rel.CleanUploadUrl() + "?" + v.Encode()
 
 	resp, err := DoAuthRequest("POST", url, "application/octet-stream",
@@ -269,7 +272,7 @@ func releasecmd(opt Options) error {
 	}
 
 	uri := fmt.Sprintf("/repos/%s/%s/releases", user, repo)
-	resp, err := DoAuthRequest("POST", API_URL+uri, "application/json", token, reader)
+	resp, err := DoAuthRequest("POST", ApiURL()+uri, "application/json", token, reader)
 	if err != nil {
 		return fmt.Errorf("while submitting %v, %v", rawjson, err)
 	}
@@ -307,7 +310,7 @@ func deletecmd(opt Options) error {
 
 	vprintf("release %v has id %v\n", tag, id)
 
-	resp, err := httpDelete(API_URL+fmt.Sprintf("/repos/%s/%s/releases/%d",
+	resp, err := httpDelete(ApiURL()+fmt.Sprintf("/repos/%s/%s/releases/%d",
 		user, repo, id), token)
 	if err != nil {
 		return fmt.Errorf("release deletion unsuccesful, %v", err)


### PR DESCRIPTION
GHE's API is a few releases behind github.com's and will catch up soon, so no additional changes needed. This PR renames the env var to match the others, and updates one more hard-coded URL (used in creating/uploading releases) to allow for the override.
