### PR TITLE
Add download support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+github-release
 go-app
 bin/
 

--- a/api.go
+++ b/api.go
@@ -11,10 +11,11 @@ import (
 
 const (
 	API_URL = "https://api.github.com"
+	GH_URL  = "https://github.com"
 )
 
 /* create a new request that sends the auth token */
-func NewAuthRequest(method, url, bodyType, token string, body io.Reader) (*http.Request, error) {
+func NewAuthRequest(method, url, bodyType, token string, headers map[string]string, body io.Reader) (*http.Request, error) {
 	vprintln("creating request:", method, url, bodyType, token)
 
 	req, err := http.NewRequest(method, url, body)
@@ -43,14 +44,20 @@ func NewAuthRequest(method, url, bodyType, token string, body io.Reader) (*http.
 		}
 	}
 
-	req.Header.Set("Content-Type", bodyType)
+	if bodyType != "" {
+		req.Header.Set("Content-Type", bodyType)
+	}
 	req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 
 	return req, nil
 }
 
-func DoAuthRequest(method, url, bodyType, token string, body io.Reader) (*http.Response, error) {
-	req, err := NewAuthRequest(method, url, bodyType, token, body)
+func DoAuthRequest(method, url, bodyType, token string, headers map[string]string, body io.Reader) (*http.Response, error) {
+	req, err := NewAuthRequest(method, url, bodyType, token, headers, body)
 	if err != nil {
 		return nil, err
 	}

--- a/assets.go
+++ b/assets.go
@@ -4,6 +4,10 @@ import (
 	"time"
 )
 
+const (
+	ASSET_DOWNLOAD_URI = "/repos/%s/%s/releases/assets/%d"
+)
+
 type Asset struct {
 	Url         string    `json:"url"`
 	Id          int       `json:"id"`

--- a/github-release.go
+++ b/github-release.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/voxelbrain/goptions"
 	"os"
+
+	"github.com/voxelbrain/goptions"
 )
 
 type Options struct {
@@ -12,6 +13,13 @@ type Options struct {
 	Quiet     bool          `goptions:"-q, --quiet, description='Do not print anything, even errors (except if --verbose is specified)'"`
 
 	goptions.Verbs
+	Download struct {
+		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
+		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag   string `goptions:"-t, --tag, description='Git tag to upload for', obligatory"`
+		Name  string `goptions:"-n, --name, description='Name of the file', obligatory"`
+	} `goptions:"download"`
 	Upload struct {
 		Token string   `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
 		User  string   `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
@@ -47,20 +55,22 @@ type Options struct {
 		Tag   string `goptions:"-t, --tag, obligatory, description='Git tag of release to delete'"`
 	} `goptions:"delete"`
 	Info struct {
-		User string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
-		Repo string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
-		Tag  string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
+		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
+		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
 	} `goptions:"info"`
 }
 
 type Command func(Options) error
 
 var commands = map[goptions.Verbs]Command{
-	"upload":  uploadcmd,
-	"release": releasecmd,
-	"edit":    editcmd,
-	"delete":  deletecmd,
-	"info":    infocmd,
+	"download": downloadcmd,
+	"upload":   uploadcmd,
+	"release":  releasecmd,
+	"edit":     editcmd,
+	"delete":   deletecmd,
+	"info":     infocmd,
 }
 
 var (

--- a/releases.go
+++ b/releases.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"strings"
 	"time"
+
+	"github.com/dustin/go-humanize"
 )
 
 const (
-	RELEASE_LIST_URI = "/repos/%s/%s/releases"
+	RELEASE_LIST_URI = "/repos/%s/%s/releases%s"
 )
 
 type Release struct {
@@ -65,9 +66,12 @@ type ReleaseCreate struct {
 	Prerelease      bool   `json:"prerelease"`
 }
 
-func Releases(user, repo string) ([]Release, error) {
+func Releases(user, repo, token string) ([]Release, error) {
+	if token != "" {
+		token = "?access_token=" + token
+	}
 	var releases []Release
-	err := GithubGet(fmt.Sprintf(RELEASE_LIST_URI, user, repo), &releases)
+	err := GithubGet(fmt.Sprintf(RELEASE_LIST_URI, user, repo, token), &releases)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +79,8 @@ func Releases(user, repo string) ([]Release, error) {
 	return releases, nil
 }
 
-func ReleaseOfTag(user, repo, tag string) (*Release, error) {
-	releases, err := Releases(user, repo)
+func ReleaseOfTag(user, repo, tag, token string) (*Release, error) {
+	releases, err := Releases(user, repo, token)
 	if err != nil {
 		return nil, err
 	}
@@ -91,8 +95,8 @@ func ReleaseOfTag(user, repo, tag string) (*Release, error) {
 }
 
 /* find the release-id of the specified tag */
-func IdOfTag(user, repo, tag string) (int, error) {
-	release, err := ReleaseOfTag(user, repo, tag)
+func IdOfTag(user, repo, tag, token string) (int, error) {
+	release, err := ReleaseOfTag(user, repo, tag, token)
 	if err != nil {
 		return 0, err
 	}

--- a/tags.go
+++ b/tags.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	TAGS_URI = "/repos/%s/%s/tags"
+	TAGS_URI = "/repos/%s/%s/tags%s"
 )
 
 type Tag struct {
@@ -20,9 +20,14 @@ func (t *Tag) String() string {
 }
 
 /* get the tags associated with a repo */
-func Tags(user, repo string) ([]Tag, error) {
+func Tags(user, repo, token string) ([]Tag, error) {
 	var tags []Tag
-	err := GithubGet(fmt.Sprintf(TAGS_URI, user, repo), &tags)
+
+	if token != "" {
+		token = "?access_token=" + token
+	}
+
+	err := GithubGet(fmt.Sprintf(TAGS_URI, user, repo, token), &tags)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds a new "download" command that will download a named asset from
a release to the current directory.  Both public and private repos are
supported.  Info command now also supports private repos to simplifly
listing assets to download over the command-line.
