### PR TITLE
fix bug in the 'info' cmd, make it more robust

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -42,7 +42,7 @@ func (r *Release) String() string {
 
 	str := make([]string, len(r.Assets)+1)
 	str[0] = fmt.Sprintf(
-		"%5s, name: '%s', description: '%s', id: %d, tagged: %s, published: %s, draft: %v, prerelease: %v",
+		"%s, name: '%s', description: '%s', id: %d, tagged: %s, published: %s, draft: %v, prerelease: %v",
 		r.TagName, r.Name, r.Description, r.Id,
 		r.Created.Format(format),
 		r.Published.Format(format),


### PR DESCRIPTION
One of the arguments wasn't being sourced correctly. I'd like to find a
better solution to the current argument duplicating because it's not DRY and
leads to these kinds of copy-paste bugs.

The command should detect failure a bit better now too.
