### PR TITLE
Add --target option to the "release" command

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -246,6 +246,7 @@ func releasecmd(opt Options) error {
 	tag := cmdopt.Tag
 	name := nvls(cmdopt.Name, tag)
 	desc := nvls(cmdopt.Desc, tag)
+	target := nvls(cmdopt.Target)
 	draft := cmdopt.Draft
 	prerelease := cmdopt.Prerelease
 
@@ -256,11 +257,12 @@ func releasecmd(opt Options) error {
 	}
 
 	params := ReleaseCreate{
-		TagName:    tag,
-		Name:       name,
-		Body:       desc,
-		Draft:      draft,
-		Prerelease: prerelease,
+		TagName:         tag,
+		TargetCommitish: target,
+		Name:            name,
+		Body:            desc,
+		Draft:           draft,
+		Prerelease:      prerelease,
 	}
 
 	/* encode params as json */

--- a/github-release.go
+++ b/github-release.go
@@ -35,6 +35,7 @@ type Options struct {
 		Tag        string `goptions:"-t, --tag, obligatory, description='Git tag to create a release from'"`
 		Name       string `goptions:"-n, --name, description='Name of the release (defaults to tag)'"`
 		Desc       string `goptions:"-d, --description, description='Description of the release (defaults to tag)'"`
+		Target     string `goptions:"-c, --target, description='Commit SHA or branch to create release of (defaults to the repository default branch)'"`
 		Draft      bool   `goptions:"--draft, description='The release is a draft'"`
 		Prerelease bool   `goptions:"-p, --pre-release, description='The release is a pre-release'"`
 	} `goptions:"release"`


### PR DESCRIPTION
This was requested in #12, and as the code more or less already supported it, it was just a matter of adding a command line option and add the value of that to the call to GitHub.

I have only added it to the `release` sub-command as I'm not sure it makes sense on the `edit` command, even though the [GitHub API](https://developer.github.com/v3/repos/releases/#edit-a-release) supports it. I couldn't get it to have the desired effect at least, since you don't seem to be able to change the target of an existing tag via the API.