### PR TITLE
Add --latest option to the "download" command

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -155,17 +155,17 @@ func downloadcmd(opt Options) error {
 		return err
 	}
 
-	var rel Release
+	var rel *Release
 	var err error
-
 
 	if latest == false	{		/* find the release corresponding to the entered tag, if any */
 		rel, err = ReleaseOfTag(user, repo, tag, token)
-		if err != nil {
-			return err
-		}
 	} else {
 		rel, err = LatestRelease(user, repo, token)
+	}
+
+	if err != nil {
+		return err
 	}
 
 

--- a/cmd.go
+++ b/cmd.go
@@ -147,18 +147,27 @@ func downloadcmd(opt Options) error {
 	token := nvls(opt.Download.Token, EnvToken)
 	tag := opt.Download.Tag
 	name := opt.Download.Name
+	latest:= opt.Download.Latest
 
 	vprintln("downloading...")
 
-	if err := ValidateTarget(user, repo, tag); err != nil {
+	if err := ValidateTarget(user, repo, tag,latest); err != nil {
 		return err
 	}
 
-	/* find the release corresponding to the entered tag, if any */
-	rel, err := ReleaseOfTag(user, repo, tag, token)
-	if err != nil {
-		return err
+	var rel Release
+	var err error
+
+
+	if latest == false	{		/* find the release corresponding to the entered tag, if any */
+		rel, err = ReleaseOfTag(user, repo, tag, token)
+		if err != nil {
+			return err
+		}
+	} else {
+		rel, err = LatestRelease(user, repo, token)
 	}
+
 
 	assetId := 0
 	for _, asset := range rel.Assets {
@@ -215,21 +224,21 @@ func downloadcmd(opt Options) error {
 	return nil
 }
 
-func ValidateTarget(user, repo, tag string) error {
+func ValidateTarget(user, repo, tag string,latest bool) error {
 	if user == "" {
 		return fmt.Errorf("empty user")
 	}
 	if repo == "" {
 		return fmt.Errorf("empty repo")
 	}
-	if tag == "" {
+	if tag == ""  && !latest{
 		return fmt.Errorf("empty tag")
 	}
 	return nil
 }
 
 func ValidateCredentials(user, repo, token, tag string) error {
-	if err := ValidateTarget(user, repo, tag); err != nil {
+	if err := ValidateTarget(user, repo, tag,false); err != nil {
 		return err
 	}
 	if token == "" {

--- a/github-release.go
+++ b/github-release.go
@@ -14,11 +14,12 @@ type Options struct {
 
 	goptions.Verbs
 	Download struct {
-		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
-		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
-		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
-		Tag   string `goptions:"-t, --tag, description='Git tag to download from', obligatory"`
-		Name  string `goptions:"-n, --name, description='Name of the file', obligatory"`
+		Token 	string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
+		User  	string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo  	string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Latest  bool `goptions:"-l, --latest, description='Download latest release (required if tag is not specified)',mutexgroup='input'"`
+		Tag   	string `goptions:"-t, --tag, description='Git tag to download from (required if latest is not specified)', mutexgroup='input',obligatory"`
+		Name  	string `goptions:"-n, --name, description='Name of the file', obligatory"`
 	} `goptions:"download"`
 	Upload struct {
 		Token string   `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`

--- a/releases.go
+++ b/releases.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	RELEASE_LIST_URI    = "/repos/%s/%s/releases%s"
+	RELEASE_LATEST_URI    = "/repos/%s/%s/releases/latest%s"
 	RELEASE_DATE_FORMAT = "02/01/2006 at 15:04"
 )
 
@@ -76,6 +77,16 @@ func Releases(user, repo, token string) ([]Release, error) {
 	}
 
 	return releases, nil
+}
+
+func LatestRelease(user, repo, token string) (*Release, error) {
+	var release Release
+	err := GithubGet(fmt.Sprintf(RELEASE_LATEST_URI, user, repo, token), &release)
+
+	if err != nil {
+		return nil, err
+	}
+	return &release, nil
 }
 
 func ReleaseOfTag(user, repo, tag, token string) (*Release, error) {

--- a/releases.go
+++ b/releases.go
@@ -92,12 +92,10 @@ func LatestReleaseApi(user, repo, token string) (*Release, error) {
 }
 
 func LatestRelease(user, repo, token string) (*Release, error) {
-	var latestRelease *Release
 	latestRelease, err := LatestReleaseApi(user, repo, token)
 
 	// enterprise api doesnt support the latest release endpoint
 	// get all releases and see published date to get the latest
-
 	if err != nil {
 		releases, err := Releases(user, repo, token)
 		if err != nil {
@@ -113,10 +111,12 @@ func LatestRelease(user, repo, token string) (*Release, error) {
 			}
 		}
 		if(latestRelIndex!=-1) {
-			latestRelease = &releases[latestRelIndex]
+			vprintln("latest release is ->",&releases[latestRelIndex])
+			return &releases[latestRelIndex],nil
 		}
+		return nil, fmt.Errorf("could not find the latest release")
+
 	}
-	vprintln("latest release is ->",latestRelease)
 	return latestRelease, nil
 }
 


### PR DESCRIPTION
Pull request for resolving #21 . Added an option --latest or -l which tries to use the latest release api to get the latest release.
If this api is not supported (as in some enterprise versions) it falls back to listing all the releases and picking the release with the latest published date.