### PR TITLE
Skip unpublished releases

### DIFF
--- a/releases.go
+++ b/releases.go
@@ -103,6 +103,9 @@ func LatestRelease(user, repo, token string) (*Release, error) {
 	var latestRelIndex = -1
 	maxDate := time.Time{}
 	for i, release := range releases {
+		if release.Published == nil {
+			continue
+		}
 		if relDate := *release.Published; relDate.After(maxDate) {
 			maxDate = relDate
 			latestRelIndex = i


### PR DESCRIPTION
If I try to download the latest release for a project which has only a draft release, I get this:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0xfe0f]

goroutine 1 [running]:
main.LatestRelease(0x7fff5fbffac3, 0xf, 0x7fff5fbffad6, 0x5, 0xc82001400d, 0x28, 0xc820010c01, 0x0, 0x0)
    /Users/john/go/src/github.com/aktau/github-release/releases.go:106 +0x7ff
main.downloadcmd(0x0, 0x0, 0x0, 0x0, 0x0, 0x7fff5fbffab7, 0x8, 0x0, 0x0, 0x7fff5fbffac3, ...)
    /Users/john/go/src/github.com/aktau/github-release/cmd.go:169 +0x545
main.main()
    /Users/john/go/src/github.com/aktau/github-release/github-release.go:116 +0x24a

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
    /usr/local/Cellar/go/1.5.1/libexec/src/runtime/asm_amd64.s:1696 +0x1

goroutine 23 [runnable]:
net/http.(*persistConn).writeLoop(0xc8200c6160)
    /usr/local/Cellar/go/1.5.1/libexec/src/net/http/transport.go:1009 +0x40c
created by net/http.(*Transport).dialConn
    /usr/local/Cellar/go/1.5.1/libexec/src/net/http/transport.go:686 +0xc9d
```

This appears to be because github-release doesn't check the presence of `Published` on a release when trying to find the latest.

Here's a patch :bowtie:  !
