### PR TITLE
Add -R/--replace flag for upload

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -110,6 +110,28 @@ func uploadcmd(opt Options) error {
 		return err
 	}
 
+	if opt.Upload.Replace {
+		for _, asset := range rel.Assets {
+			if asset.Name == name {
+				vprintln("deleting previous asset version for ", name)
+
+				resp, err := httpDelete(ApiURL()+fmt.Sprintf(ASSET_DOWNLOAD_URI,
+					user, repo, asset.Id), token)
+				if resp != nil {
+					defer resp.Body.Close()
+				}
+				if err != nil {
+					return fmt.Errorf("previous version deletion unsuccessful, %v", err)
+				}
+
+				if resp.StatusCode != http.StatusNoContent {
+					return fmt.Errorf("could not delete the previous version of %s on repo %s/%s",
+						name, user, repo)
+				}
+			}
+		}
+	}
+
 	v := url.Values{}
 	v.Set("name", name)
 	if label != "" {
@@ -403,7 +425,7 @@ func deletecmd(opt Options) error {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		return fmt.Errorf("release deletion unsuccesful, %v", err)
+		return fmt.Errorf("release deletion unsuccessful, %v", err)
 	}
 
 	if resp.StatusCode != http.StatusNoContent {

--- a/github-release.go
+++ b/github-release.go
@@ -23,13 +23,14 @@ type Options struct {
 		Name   string `goptions:"-n, --name, description='Name of the file', obligatory"`
 	} `goptions:"download"`
 	Upload struct {
-		Token string   `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
-		User  string   `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
-		Repo  string   `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
-		Tag   string   `goptions:"-t, --tag, description='Git tag to upload to', obligatory"`
-		Name  string   `goptions:"-n, --name, description='Name of the file', obligatory"`
-		Label string   `goptions:"-l, --label, description='Label (description) of the file'"`
-		File  *os.File `goptions:"-f, --file, description='File to upload (use - for stdin)', rdonly, obligatory"`
+		Token   string   `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
+		User    string   `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo    string   `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag     string   `goptions:"-t, --tag, description='Git tag to upload to', obligatory"`
+		Name    string   `goptions:"-n, --name, description='Name of the file', obligatory"`
+		Label   string   `goptions:"-l, --label, description='Label (description) of the file'"`
+		File    *os.File `goptions:"-f, --file, description='File to upload (use - for stdin)', rdonly, obligatory"`
+		Replace bool     `goptions:"-R, --replace, description='Replace upload with same name if already exists'"`
 	} `goptions:"upload"`
 	Release struct {
 		Token      string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`


### PR DESCRIPTION
This is a soft version of #38 - it allows someone to implement an external retry logic while relying on github-release to delete previous versions of an asset.