### PR TITLE
Closes #53 makes help output for --user less confusing

### DIFF
--- a/github-release.go
+++ b/github-release.go
@@ -16,7 +16,7 @@ type Options struct {
 	goptions.Verbs
 	Download struct {
 		Token  string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
-		User   string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		User   string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo   string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Latest bool   `goptions:"-l, --latest, description='Download latest release (required if tag is not specified)',mutexgroup='input'"`
 		Tag    string `goptions:"-t, --tag, description='Git tag to download from (required if latest is not specified)', mutexgroup='input',obligatory"`
@@ -24,7 +24,7 @@ type Options struct {
 	} `goptions:"download"`
 	Upload struct {
 		Token string   `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
-		User  string   `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		User  string   `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo  string   `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag   string   `goptions:"-t, --tag, description='Git tag to upload to', obligatory"`
 		Name  string   `goptions:"-n, --name, description='Name of the file', obligatory"`
@@ -33,7 +33,7 @@ type Options struct {
 	} `goptions:"upload"`
 	Release struct {
 		Token      string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
-		User       string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		User       string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo       string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag        string `goptions:"-t, --tag, obligatory, description='Git tag to create a release from'"`
 		Name       string `goptions:"-n, --name, description='Name of the release (defaults to tag)'"`
@@ -44,7 +44,7 @@ type Options struct {
 	} `goptions:"release"`
 	Edit struct {
 		Token      string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
-		User       string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		User       string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo       string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag        string `goptions:"-t, --tag, obligatory, description='Git tag to edit the release of'"`
 		Name       string `goptions:"-n, --name, description='New name of the release (defaults to tag)'"`
@@ -54,13 +54,13 @@ type Options struct {
 	} `goptions:"edit"`
 	Delete struct {
 		Token string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
-		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		User  string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag   string `goptions:"-t, --tag, obligatory, description='Git tag of release to delete'"`
 	} `goptions:"delete"`
 	Info struct {
 		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
-		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		User  string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
 	} `goptions:"info"`


### PR DESCRIPTION
Writing `repo user or organisation` makes it easier to understand it's the repository user, not a local user using the command line.

See #53 

```
 ./github-release -h                                             
Usage: github-release [global options] <verb> [verb options]

Global options:
        -h, --help           Show this help
        -v, --verbose        Be verbose
        -q, --quiet          Do not print anything, even errors (except if --verbose is specified)
            --version        Print version

Verbs:
    delete:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag of release to delete (*)
    download:
        -s, --security-token Github token ($GITHUB_TOKEN if set). required if repo is private.
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -l, --latest         Download latest release (required if tag is not specified)
        -t, --tag            Git tag to download from (required if latest is not specified) (*)
        -n, --name           Name of the file (*)
    edit:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to edit the release of (*)
        -n, --name           New name of the release (defaults to tag)
        -d, --description    New description of the release (defaults to tag)
            --draft          The release is a draft
        -p, --pre-release    The release is a pre-release
    info:
        -s, --security-token Github token ($GITHUB_TOKEN if set). required if repo is private.
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to query (optional)
    release:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to create a release from (*)
        -n, --name           Name of the release (defaults to tag)
        -d, --description    Description of the release (defaults to tag)
        -c, --target         Commit SHA or branch to create release of (defaults to the repository default branch)
            --draft          The release is a draft
        -p, --pre-release    The release is a pre-release
    upload:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to upload to (*)
        -n, --name           Name of the file (*)
        -l, --label          Label (description) of the file
        -f, --file           File to upload (use - for stdin) (*)
```