### PR TITLE
Add deletef command to delete a file in a release

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -433,20 +433,16 @@ func deletefilecmd(opt Options) error {
 		return err
 	}
 
-	assetId := 0
-	for _, asset := range rel.Assets {
-		if asset.Name == name {
-			assetId = asset.Id
-		}
-	}
-
-	if assetId == 0 {
+	assetID := findAssetID(rel.Assets, name)
+	if assetID == -1 {
 		return fmt.Errorf("coud not find asset named %s", name)
 	}
-	vprintf("release %v has assetId %v\n", tag, assetId)
 
-	resp, err := DoAuthRequest("DELETE", ApiURL()+fmt.Sprintf("/repos/%s/%s/releases/%d",
-		user, repo, assetId), "application/json", token, nil, nil)
+	vprintf("release %v has assetID %v\n", tag, assetID)
+
+	baseURL := nvls(EnvApiEndpoint, github.DefaultBaseURL)
+	resp, err := github.DoAuthRequest("DELETE", baseURL+fmt.Sprintf("/repos/%s/%s/releases/%d",
+		user, repo, assetID), "application/json", token, nil, nil)
 	if err != nil {
 		return fmt.Errorf("release file deletion unsuccesful, %v", err)
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -448,13 +448,13 @@ func deletefilecmd(opt Options) error {
 	resp, err := DoAuthRequest("DELETE", ApiURL()+fmt.Sprintf("/repos/%s/%s/releases/%d",
 		user, repo, assetId), "application/json", token, nil, nil)
 	if err != nil {
-		return fmt.Errorf("release deletion unsuccesful, %v", err)
+		return fmt.Errorf("release file deletion unsuccesful, %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("could not delete the release corresponding to tag %s on repo %s/%s",
-			tag, user, repo)
+		return fmt.Errorf("could not delete the release file corresponding to tag %s on repo %s/%s/%s",
+			tag, user, repo, name)
 	}
 
 	return nil

--- a/github-release.go
+++ b/github-release.go
@@ -62,6 +62,13 @@ type Options struct {
 		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag   string `goptions:"-t, --tag, obligatory, description='Git tag of release to delete'"`
 	} `goptions:"delete"`
+	DeleteFile struct {
+		Token string `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`
+		User  string `goptions:"-u, --user, description='Github user (required if $GITHUB_USER not set)'"`
+		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag   string `goptions:"-t, --tag, obligatory, description='Git tag of release to delete'"`
+		Name  string `goptions:"-n, --name, description='Name of the file to be deleted', obligatory"`
+	} `goptions:"deletef"`
 	Info struct {
 		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
 		User  string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
@@ -78,6 +85,7 @@ var commands = map[goptions.Verbs]Command{
 	"release":  releasecmd,
 	"edit":     editcmd,
 	"delete":   deletecmd,
+	"deletef":  deletefilecmd,
 	"info":     infocmd,
 }
 


### PR DESCRIPTION
This solves #52.

It is possible to performs something like below now.
```
for file in bin/*; do
  name=$(basename $file)
  github-release deletef -u "$owner" -r "$repo" -t "$tag" -n "$name"
  github-release upload -u "$owner" -r "$repo" -t "$tag" -n "$name" -f "$file"
done
```
It is possible to expand existing delete command for my purpose, but it may causes unexpected release deletes.  Therefore, I made different deletef command.