### PR TITLE
Add --stdout option to print downloaded file to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ on the [releases
 page](https://github.com/aktau/github-release/releases/latest). Yes, that's
 dogfooding, check the makefile!
 
+To install and unzip the `github-release` binary to the current directory in one
+line, via `curl`:
+
+```
+# Substitute "linux" for your platform as appropriate
+curl --silent --location https://github.com/aktau/github-release/releases/download/v0.6.2/linux-amd64-github-release.tar.bz2 | tar -j --strip-components=3 -x bin/linux/amd64/github-release
+```
+
 If you have Go installed, you can just do:
 
 ```sh

--- a/github-release.go
+++ b/github-release.go
@@ -21,6 +21,7 @@ type Options struct {
 		Latest bool   `goptions:"-l, --latest, description='Download latest release (required if tag is not specified)',mutexgroup='input'"`
 		Tag    string `goptions:"-t, --tag, description='Git tag to download from (required if latest is not specified)', mutexgroup='input',obligatory"`
 		Name   string `goptions:"-n, --name, description='Name of the file', obligatory"`
+		Stdout bool   `goptions:"-d, --stdout, description='Write the downloaded file to stdout, instead of to a file'"`
 	} `goptions:"download"`
 	Upload struct {
 		Token string   `goptions:"-s, --security-token, description='Github token (required if $GITHUB_TOKEN not set)'"`


### PR DESCRIPTION
I'm trying to use github-release to download assets in a CI
environment, and it's more convenient to be able to pipe the assets
directly to tar/unzip than to have to write them to a file and call
tar separately. Adds a `--stdout` flag that will write downloaded
files to os.Stdout instead of to disk.