### PR TITLE
JSON output for `info` command

### DIFF
--- a/github-release.go
+++ b/github-release.go
@@ -67,6 +67,7 @@ type Options struct {
 		User  string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
 		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
 		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
+		JSON  bool   `goptions:"-j, --json, description='Emit info as JSON instead of text'"`
 	} `goptions:"info"`
 }
 


### PR DESCRIPTION
Background: This PR is a followup to the discussion in issue #64 about providing an option for JSON-formatted output for the `info` command.

* Added `--json/-j' flag to info command along with corresponding renderers for both txt and JSON.

Example output:

```bash
go build -o github-release
./github-release info --json -u jaytaylor -r ansible-kafka
```
```json
{
    "Tags": [
        {
            "name": "v1.2.0",
            "commit": {
                "sha": "c401193b0eae9e3f4d69526a409c5d521ca9eec8",
                "url": "https://api.github.com/repos/jaytaylor/ansible-kafka/commits/c401193b0eae9e3f4d69526a409c5d521ca9eec8"
            },
            "zipball_url": "https://api.github.com/repos/jaytaylor/ansible-kafka/zipball/v1.2.0",
            "tarball_url": "https://api.github.com/repos/jaytaylor/ansible-kafka/tarball/v1.2.0"
        },
        {
            "name": "v1.1.0",
            "commit": {
                "sha": "f7c06327dc278e03bf4bf1f42077f9908d89ae67",
                "url": "https://api.github.com/repos/jaytaylor/ansible-kafka/commits/f7c06327dc278e03bf4bf1f42077f9908d89ae67"
            },
            "zipball_url": "https://api.github.com/repos/jaytaylor/ansible-kafka/zipball/v1.1.0",
            "tarball_url": "https://api.github.com/repos/jaytaylor/ansible-kafka/tarball/v1.1.0"
        },
        {
            "name": "v1.0.0",
            "commit": {
                "sha": "c9cfe5dabcfd8df3fb7ebe94f17a29e1f47bd055",
                "url": "https://api.github.com/repos/jaytaylor/ansible-kafka/commits/c9cfe5dabcfd8df3fb7ebe94f17a29e1f47bd055"
            },
            "zipball_url": "https://api.github.com/repos/jaytaylor/ansible-kafka/zipball/v1.0.0",
            "tarball_url": "https://api.github.com/repos/jaytaylor/ansible-kafka/tarball/v1.0.0"
        }
    ],
    "Releases": [
        {
            "url": "https://api.github.com/repos/jaytaylor/ansible-kafka/releases/5601532",
            "html_url": "https://github.com/jaytaylor/ansible-kafka/releases/tag/v1.2.0",
            "upload_url": "https://uploads.github.com/repos/jaytaylor/ansible-kafka/releases/5601532/assets{?name,label}",
            "id": 5601532,
            "name": "ansible-kafka-v1.2.0",
            "body": "Installation user and group overrides are now available.\n",
            "tag_name": "v1.2.0",
            "draft": false,
            "prerelease": false,
            "created_at": "2017-03-01T04:16:51Z",
            "published_at": "2017-03-01T04:19:07Z",
            "assets": []
        },
        {
            "url": "https://api.github.com/repos/jaytaylor/ansible-kafka/releases/5070963",
            "html_url": "https://github.com/jaytaylor/ansible-kafka/releases/tag/v1.1.0",
            "upload_url": "https://uploads.github.com/repos/jaytaylor/ansible-kafka/releases/5070963/assets{?name,label}",
            "id": 5070963,
            "name": "ansible-kafka-v1.1.0",
            "body": "Kafka 0.9.x compatibility, additional variables and miscellaneous improvements.\n\nSee https://github.com/jaytaylor/ansible-kafka/compare/v1.0.0...v1.1.0 for all new commits since the last release.\n",
            "tag_name": "v1.1.0",
            "draft": false,
            "prerelease": false,
            "created_at": "2017-01-03T17:32:18Z",
            "published_at": "2017-01-04T21:10:20Z",
            "assets": []
        },
        {
            "url": "https://api.github.com/repos/jaytaylor/ansible-kafka/releases/2634718",
            "html_url": "https://github.com/jaytaylor/ansible-kafka/releases/tag/v1.0.0",
            "upload_url": "https://uploads.github.com/repos/jaytaylor/ansible-kafka/releases/2634718/assets{?name,label}",
            "id": 2634718,
            "name": "ansible-kafka-v1.0.0",
            "body": "For Ansible-Galaxy compatibility\n",
            "tag_name": "v1.0.0",
            "draft": false,
            "prerelease": false,
            "created_at": "2016-02-17T16:56:30Z",
            "published_at": "2016-02-17T19:12:02Z",
            "assets": []
        }
    ]
}
```
