### PR TITLE
Add support for InsecureSkipVerify

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/aktau/github-release/github"
+	"github.com/deejross/github-release/github"
 )
 
 const (

--- a/cmd.go
+++ b/cmd.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/aktau/github-release/github"
+	"github.com/deejross/github-release/github"
 )
 
 func infocmd(opt Options) error {

--- a/github-release.go
+++ b/github-release.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/aktau/github-release/github"
+	"github.com/deejross/github-release/github"
 	"github.com/voxelbrain/goptions"
 )
 

--- a/releases.go
+++ b/releases.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aktau/github-release/github"
+	"github.com/deejross/github-release/github"
 	"github.com/dustin/go-humanize"
 )
 

--- a/tags.go
+++ b/tags.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/aktau/github-release/github"
+	"github.com/deejross/github-release/github"
 )
 
 const (


### PR DESCRIPTION
Overriding the SSL cert check can be important when using GitHub Enterprise. This adds support for this by setting the value of the `INSECURE` environment variable to a non-empty string.

Example:
```bash
INSECURE=1 github-release release --user deejross --repo mydis --tag v0.6.0 --name "Version 0.6.0" --description "The next version"
```