### PR TITLE
Add a simple markdown changelog output format.

### DIFF
--- a/github-release.go
+++ b/github-release.go
@@ -63,11 +63,13 @@ type Options struct {
 		Tag   string `goptions:"-t, --tag, obligatory, description='Git tag of release to delete'"`
 	} `goptions:"delete"`
 	Info struct {
-		Token string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
-		User  string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
-		Repo  string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
-		Tag   string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
-		JSON  bool   `goptions:"-j, --json, description='Emit info as JSON instead of text'"`
+		Token      string `goptions:"-s, --security-token, description='Github token ($GITHUB_TOKEN if set). required if repo is private.'"`
+		User       string `goptions:"-u, --user, description='Github repo user or organisation (required if $GITHUB_USER not set)'"`
+		Repo       string `goptions:"-r, --repo, description='Github repo (required if $GITHUB_REPO not set)'"`
+		Tag        string `goptions:"-t, --tag, description='Git tag to query (optional)'"`
+		JSON       bool   `goptions:"-j, --json, description='Emit info as JSON instead of text'"`
+		Markdown   bool   `goptions:"-m, --markdown, description='Emit info as human readable markdown changelog.md'"`
+		Prerelease bool   `goptions:"-p, --pre-release, description='Include pre-releases in markdown output'"`
 	} `goptions:"info"`
 }
 


### PR DESCRIPTION
We want to use this for changelogs on our public repos related to Certificate Transparency. For example: https://github.com/google/trillian/blob/master/CHANGELOG.md.

I don't see an authors / contributors file but if there is something like this my employer would like you to add Google LLC to it. Thanks!