### PR TITLE
Use latest release tag If enabled latest option

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -236,6 +236,9 @@ func downloadcmd(opt Options) error {
 	var resp *http.Response
 	if token == "" {
 		// Use the regular github.com site if we don't have a token.
+		if latest {
+			tag = rel.TagName
+		}
 		resp, err = http.Get("https://github.com" + fmt.Sprintf("/%s/%s/releases/download/%s/%s", user, repo, tag, name))
 	} else {
 		url := nvls(EnvApiEndpoint, github.DefaultBaseURL) + fmt.Sprintf(ASSET_URI, user, repo, asset.Id)


### PR DESCRIPTION
When using the latest option without token, the API returns 404 because tag is empty.

```sh
$ github-release download -u user -r public-repo --latest -n example_darwin_amd64.tar.gz
error: strconv.ParseInt: parsing "": invalid syntax
```

 So use the tag name got with latest api.